### PR TITLE
updated socketService to handle auto rejoin rooms/state recovery

### DIFF
--- a/ws_server/src/db/dynamoService.ts
+++ b/ws_server/src/db/dynamoService.ts
@@ -9,7 +9,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { fromEnv } from "@aws-sdk/credential-providers";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { getCurrentTimeStamp } from "src/utils/helpers.js";
+import { getCurrentTimeStamp } from "../utils/helpers.js";
 
 const clientConfig: DynamoDBClientConfig = { credentials: fromEnv() };
 const client = new DynamoDBClient(clientConfig);

--- a/ws_server/src/db/redisService.ts
+++ b/ws_server/src/db/redisService.ts
@@ -1,5 +1,5 @@
 import { Redis } from "ioredis"
-import { getCurrentTimeStamp } from "src/utils/helpers.js";
+import { getCurrentTimeStamp } from "../utils/helpers.js";
 import "dotenv/config"
 
 /*

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -75,5 +75,5 @@ app.post('/api/postman/dynamo', dynamoPostmanRoute);
 // listening on port 3001
 
 httpServer.listen(PORT, () => {
-  console.log('listening on port', PORT);
+  console.log('TwineServer listening on port', PORT);
 });

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { io } from '../index.js';
-import { createMessage } from "src/db/dynamoService.js";
+import { createMessage } from "../db/dynamoService.js";
 import { storeMessageInSet } from '../db/redisService.js';
 
 export const homeRoute = (req: Request, res: Response) => {
@@ -50,7 +50,7 @@ export const dynamoPostmanRoute = async (req: Request, res: Response) => {
     // console.log("data:", data);
     // console.log('SENT POSTMAN MESSAGE:', data.payload);
     
-    io.to("room 1").emit("message", messageData);
+    io.to(data.room_id).emit("message", messageData);
     
     if (dynamoResponse.status_code) {
       res.status(dynamoResponse.status_code).send('ok');

--- a/ws_server/src/services/socketServices.ts
+++ b/ws_server/src/services/socketServices.ts
@@ -1,7 +1,7 @@
 import { v4 as uuid4 } from 'uuid';
 import { Socket } from "socket.io";
 import { createSessionHash, retrieveMsgsByRoomAndTime, checkSessionTime } from '../db/redisService.js';
-import { createMessage, readPreviousMessagesByRoom } from 'src/db/dynamoService.js'; 
+import { createMessage, readPreviousMessagesByRoom } from '../db/dynamoService.js';
 
 // this is just to make sessionId a property of a socket object
 // the purpose is so that sessionId accessible within all the socket listeners
@@ -13,16 +13,6 @@ interface DynamoMessage {
   id: object;
   time_created: object;
   payload: object;
-}
-
-const dynamoFunc = async (socket: Socket) => {
-  let messageArr = await readPreviousMessagesByRoom('C', socket.handshake.auth.offset) as DynamoMessage[];
-      
-  messageArr.forEach(message => {
-    let msg = message.payload
-    let timestamp = message.time_created
-    socket.emit("message", [msg, timestamp]);
-  });
 }
 
 /*
@@ -41,25 +31,45 @@ to the client directly (not to the overall room)
 // else
   // messages should be expired/gone from cache
   // set property on socket object of reconnection type = long
-const checkReconnectionType = (sessionId: string) => {
-  const lastSessionTimestamp = checkSessionTime(sessionId);
-  if (lastSessionTimestamp > '2 Minutes!') {
-    return 'dynamo';
-  } else {
-    return 'redis';
+
+const SHORT_TERM_RECOVERY_TIME_MAX = 120000;
+const LONG_TERM_RECOVERY_TIME_MAX = 86400000;
+
+const readRedisSessionInfo = (localStorageSessionId: number) => {
+  // mocked redis session data
+  return {
+    timestamp: 1698278913080,
+    "A": "A",
+    "B": "B",
   }
 }
 
-const emitReconnectionStateRecovery = (socket: CustomSocket, reconnectionType: string, sessionId: string) => {
-  if (reconnectionType === 'redis') {
-    console.log('#### Redis Reconnection')
-    retrieveMsgsByRoomAndTime('B', sessionId);
-  } else if (reconnectionType === 'dynamo') {
-    console.log('#### Dynamo Reconnection')
-    dynamoFunc(socket)
-  } else {
-    console.log('#### Not Dynamo or Redis ??')
+const resubscribe = (socket: CustomSocket, rooms: object) => {
+  for (let room in rooms) {
+    socket.join(room);
   }
+}
+
+const emitShortTermReconnectionStateRecovery = (socket: CustomSocket, rooms: object) => {
+
+}
+
+const emitLongTermReconnectionStateRecovery = async (socket: CustomSocket, 
+                                                     rooms: object, 
+                                                     lastDisconnect: number) => {
+  console.log("lastDisconnect:", lastDisconnect);  
+  for (let room in rooms) {
+    let messages = await readPreviousMessagesByRoom(room, lastDisconnect) as DynamoMessage[];
+    emitMessages(socket, messages);
+  }
+}
+
+const emitMessages = (socket: CustomSocket, messages: DynamoMessage[]) => {
+  messages.forEach(message => {
+    let msg = message.payload
+    let timestamp = message.time_created
+    socket.emit("message", [msg, timestamp]);
+  });
 }
 
 // called when io.on(connect)
@@ -73,8 +83,40 @@ export const handleConnection = async (socket: CustomSocket) => {
     if (localStorageSessionId) { 
       console.log('#### Reconnection');
       socket.sessionId = localStorageSessionId;
-      const reconnectionType: string = checkReconnectionType(localStorageSessionId);
-      emitReconnectionStateRecovery(socket, reconnectionType, localStorageSessionId);
+      
+      // fetch session info from redis (mocked)
+      const sessionData = readRedisSessionInfo(localStorageSessionId);
+
+      // if there is no session info in redis (last disconnect > 24 hrs ago)
+      if (!sessionData) {
+        // add session info to redis and return
+        createSessionHash(localStorageSessionId);
+        return;
+      }
+      
+      // grab timestampo and rooms data
+      let { timestamp, ...rooms } = sessionData;
+      // re-subscribe to all rooms
+      resubscribe(socket, rooms);
+
+      const timeSinceLastDisconnect = Date.now() - timestamp;
+
+      console.log("timeSinceLastDisconnect:", timeSinceLastDisconnect);
+
+      if (false) { // replace with line below
+      // if (timeSinceLastDisconnect <= SHORT_TERM_RECOVERY_TIME_MAX) { // less than 2 mins (milliseconds)
+        // fetch messages from redis and emit
+        // emitShortTermReconnectionStateRecovery(socket, rooms, timestamp);
+      } else if (timeSinceLastDisconnect <= LONG_TERM_RECOVERY_TIME_MAX) { // less than 24 hrs (milliseconds)
+        // pull messages from dynamoDB for all subscribed rooms and emit
+        console.log('long term state recovery branch executed')
+        emitLongTermReconnectionStateRecovery(socket, rooms, timestamp);
+      }
+
+      // update session info
+      // set timestamp to Date.now()
+
+
     } else {
       // create uuid; save it in Redis; send it to client to store in their local storage
       console.log('#### First Connection');
@@ -98,9 +140,6 @@ export const handleConnection = async (socket: CustomSocket) => {
     let sessionId = socket.sessionId || '';
     createSessionHash(sessionId);
   })
-
-  // default always join this room, for mongoPostmanRoute
-  socket.join("room 1");
 }
 
 // interface DynamoMessage {


### PR DESCRIPTION
- Updated the branch in `handleConnection` for when a `localStorageSessionID` is valid.
  - created a mock function to simulate querying the cache `readRedisSessionInfo`.
  - Lines 91-94 will add the session to the cache if the cache hit was a fail. Then returns from function.
  - The `resubscribe` function` resubscribes to all the rooms returned from the cache.
  - Based on the `timeSinceLastDisconnect` calculation messages will be retrieved from the cache or dynamoDB and emitted back to the client. 
  
To-do:
- Need to update the session info in the cache after emitting the recovered messages.
- Thoroughly test to ensure appropriate behavior. 