### PR TITLE
fetch and return missed messages in subscribed rooms on reconnect

### DIFF
--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -38,6 +38,18 @@ socket.on("message", (messageData) => {
   window.scrollTo(0, document.body.scrollHeight);
 });
 
+// temporary, for redis message emit
+socket.on("redismessage", (messageData) => {
+  console.log('MessageData for client: ', messageData);
+  let [ message, room ] = messageData;
+  let displayMsg = `${message} from room ${room}`
+  const messages = document.getElementById('messages');
+  const item = document.createElement('li');
+  item.textContent = displayMsg;
+  messages.appendChild(item);
+  window.scrollTo(0, document.body.scrollHeight);
+});
+
 const disconnectBtn = document.getElementById('disconnect');
 disconnectBtn.addEventListener('click', (e) => {
   e.preventDefault();

--- a/ws_server/src/db/dynamoService.ts
+++ b/ws_server/src/db/dynamoService.ts
@@ -9,7 +9,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import { fromEnv } from "@aws-sdk/credential-providers";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
-import { getCurrentTimeStamp } from "src/utils/helpers.js";
+import { getCurrentTimeStamp } from "../utils/helpers.js";
 
 const clientConfig: DynamoDBClientConfig = { credentials: fromEnv() };
 const client = new DynamoDBClient(clientConfig);

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -1,6 +1,6 @@
 import { Request, Response } from "express";
 import { io } from '../index.js';
-import { createMessage } from "src/db/dynamoService.js";
+import { createMessage } from "../db/dynamoService.js";
 import { storeMessageInSet } from '../db/redisService.js';
 
 export const homeRoute = (req: Request, res: Response) => {
@@ -18,14 +18,10 @@ export const redisPostmanRoomsRoute = async (req: Request, res: Response) => {
 
   const data: jsonData = req.body
 
-  console.log('ROOM AND MESSAGE:', data.room, data.message);
-
   storeMessageInSet(data.room, data.message);
 
   // only people in this room should receive this message event
   io.to(`${data.room}`).emit("roomJoined", data.message);
-
-  console.log('SENT POSTMAN MESSAGE');
 
   res.send('ok');
 }


### PR DESCRIPTION
`socketServices`
- socket.on('join') now calls `addRoomToSession(sessionId, roomName);` from `redisServices`, adding the room the client joined to that sessionId's Redis hash
- `await allSubscribedMessages(sessionId);` is called from `redisServices` in the case of short term state recovery -- this can be called in the appropriate place in the logic Chris implemented
- other changes are for testing and can be removed during merge conflict resolution

`redisServices`
- for simplicity and fast reads, Redis sessionId keys still refer to a string timestamp value, while the rooms associated with a sessionId are a separate k/v pair -- the tradeoff is that this is less space efficient than having one hash for everything
- `addRoomToSession` is designed to be called when a client subscribes to a room -- it creates a new k/v pair where the key is `rooms:${sessionID}` and the value is a hash of k/v pairs: the values follow the k: roomName v: roomName pattern
- `removeRoomFromSession` is ready for when a client unsubscribes from a room
- `allSubscribedMessages` uses a helper function to iterate through the collection of rooms associated with a sessionId and pull from each one the messages missed since the client disconnected -- the messages are returned in an object with this structure: `{ roomA: [msg1, msg2 ...], roomB: [msg1, msg2...] }`
- that object can then be used to emit missed room message data to the client, upon short term connection recovery