### PR TITLE
Redis future work

### DIFF
--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -26,7 +26,7 @@ socket.on('setSessionId', (sessionId) => {
 // Handle successful connection
 socket.on("message", (messageData) => {
   console.log('MessageData from client', messageData);
-  let [ payload, timestamp ] = messageData;
+  let [payload, timestamp] = messageData;
 
   socket.auth.offset = timestamp; // atLeastOnce logic
   localStorage.setItem("offset", timestamp);
@@ -41,7 +41,7 @@ socket.on("message", (messageData) => {
 // temporary, for redis message emit
 socket.on("redismessage", (messageData) => {
   console.log('MessageData for client: ', messageData);
-  let [ message, room ] = messageData;
+  let [message, room] = messageData;
   let displayMsg = `${message} from room ${room}`
   const messages = document.getElementById('messages');
   const item = document.createElement('li');
@@ -85,14 +85,19 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 socket.on('roomJoined', (message) => {
-  console.log(message);
+  console.log('message to emit: ', message);
+  const messages = document.getElementById('messages');
+  const item = document.createElement('li');
+  item.textContent = message;
+  messages.appendChild(item);
+  window.scrollTo(0, document.body.scrollHeight);
 });
 
 /*
 ------ atLeastOnceFunctionality
 Need to track a users subscribed rooms to provide state recovery upon disconnect (both intentionally & unintentionally)
 
-Updated state recovery approach: 
+Updated state recovery approach:
 - Track timestamp of each room's last message
 - Capture user's disconnect time
 - Retrive messages from Redis/Dynamo based off difference
@@ -101,8 +106,8 @@ Updated state recovery approach:
 Store rooms, where? Redis sessions table
 
 
-Upon connection, check Redis, 
-- does user exist? 
+Upon connection, check Redis,
+- does user exist?
   - no? initial connection
   - yes? how long have they been disconnected?
     - under 2min?

--- a/ws_server/src/db/redisService.ts
+++ b/ws_server/src/db/redisService.ts
@@ -6,6 +6,11 @@ const redisURL = process.env.CACHE_ENDPOINT || 'redis://localhost:6379';
 const redis: Redis = new Redis(redisURL);
 console.log('Connected to Redis');
 
+interface jsonData {
+  room: string;
+  message: string;
+}
+
 
 const generateRandomStringPrefix = (payload: string) => {
   const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -25,10 +30,18 @@ const removeRandomStringPrefixs = (arrayOfMessages: string[]) => {
 }
 
 // note: payload should probably be converted to JSON before stored, to allow storing various data types
-// note: we should return 'room name < name >' does not exist error for Postman API
-export const storeMessageInSet = async (room: string, payload: string) => {
+// note: we should return 'room name < name >' does not exist error
+// for Postman API
+// export const storeMessageInSet = async (room: string, payload: string) => {
+//   let timeCreated = getCurrentTimeStamp();
+//   let randomizedPayload = generateRandomStringPrefix(payload);
+//   await redis.zadd(`${room}Set`, timeCreated, randomizedPayload);
+//   console.log('Message stored in cache: ' + randomizedPayload);
+// }
+
+export const storeMessageInSet = async (room: string, payload: jsonData) => {
   let timeCreated = getCurrentTimeStamp();
-  let randomizedPayload = generateRandomStringPrefix(payload);
+  let randomizedPayload = generateRandomStringPrefix(JSON.stringify(payload));
   await redis.zadd(`${room}Set`, timeCreated, randomizedPayload);
   console.log('Message stored in cache: ' + randomizedPayload);
 }
@@ -91,3 +104,8 @@ export const addRoomToSession = async (sessionID: string, roomName: string) => {
 export const removeRoomFromSession = async (sessionID: string, roomName: string) => {
   await redis.hdel(`rooms:${sessionID}`, roomName);
 }
+
+/*
+Pagination
+
+*/

--- a/ws_server/src/db/redisService.ts
+++ b/ws_server/src/db/redisService.ts
@@ -6,12 +6,31 @@ const redisURL = process.env.CACHE_ENDPOINT || 'redis://localhost:6379';
 const redis: Redis = new Redis(redisURL);
 console.log('Connected to Redis');
 
+
+const generateRandomStringPrefix = (payload: string) => {
+  const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+
+  for (let i = 0; i < 5; i++) {
+    const randomIndex = Math.floor(Math.random() * charset.length);
+    result += charset[randomIndex];
+  }
+
+  return result + payload;
+
+}
+
+const removeRandomStringPrefixs = (arrayOfMessages: string[]) => {
+  return arrayOfMessages.map(message => message.slice(5));
+}
+
 // note: payload should probably be converted to JSON before stored, to allow storing various data types
 // note: we should return 'room name < name >' does not exist error for Postman API
 export const storeMessageInSet = async (room: string, payload: string) => {
   let timeCreated = getCurrentTimeStamp();
-  await redis.zadd(`${room}Set`, timeCreated, payload);
-  console.log('Message stored in cache: ' + payload);
+  let randomizedPayload = generateRandomStringPrefix(payload);
+  await redis.zadd(`${room}Set`, timeCreated, randomizedPayload);
+  console.log('Message stored in cache: ' + randomizedPayload);
 }
 
 interface SubscribedRoomMessages {
@@ -27,7 +46,9 @@ export const processSubscribedRooms = async (timestamp: number, room: string, re
     if (error) {
       console.error('Error reading sorted set:', error);
     } else {
-      result[room] = array as string[];
+      let processedMessages = removeRandomStringPrefixs(array as string[]);
+      result[room] = processedMessages;
+      console.log(processedMessages);
     }
   })
 }

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -18,7 +18,8 @@ export const redisPostmanRoomsRoute = async (req: Request, res: Response) => {
 
   const data: jsonData = req.body
 
-  storeMessageInSet(data.room, data.message);
+  // storeMessageInSet(data.room, data.message);
+  storeMessageInSet(data.room, data);
 
   // only people in this room should receive this message event
   io.to(`${data.room}`).emit("roomJoined", data.message);
@@ -37,7 +38,7 @@ export const dynamoPostmanRoute = async (req: Request, res: Response) => {
   try {
     const data = req.body;
     const dynamoResponse = await createMessage(
-      data.room_id, 
+      data.room_id,
       data.payload
     ) as DynamoCreateResponse;
 
@@ -45,9 +46,9 @@ export const dynamoPostmanRoute = async (req: Request, res: Response) => {
 
     // console.log("data:", data);
     // console.log('SENT POSTMAN MESSAGE:', data.payload);
-    
+
     io.to(data.room_id).emit("message", messageData);
-    
+
     if (dynamoResponse.status_code) {
       res.status(dynamoResponse.status_code).send('ok');
     } else {


### PR DESCRIPTION
Implemented the following:

- In `messages.js` added logic to `'roomJoined'` listener so that incoming messages from the `/api/postman/rooms` route work with the front end of the chat app/ are displayed 

- Fixed bug related to enforced uniqueness of sorted sets in Redis:
  - Added a helper function `generateRandomStringPrefix` in `redisService.ts` that generates a 5 character long random string that is added to the beginning of the stringifyed payload of an incoming message to be stored in a Redis sortedSet
  - Added a helper function `removeRandomStringPrefixs` in `redisService.ts` that removes that 5 character long string when returning messages to the client in `processSubscribedRooms` 
  - This allows the same message to be sent to the client if desired 
  
- Messages are now stored as stringifyed JSON objects in Redis rather than plain strings to make the code reusable for different types of applications.
- In `redisService.ts` the `storeMessageInSet` method was modified to take a `room` argument as a string and a `payload` argument as a `jsonData` object (this interface will need to be created by the users of our applications to fit their needs, our `jsonData` interface for the purposes of the chat application is on lines 9-12). Additionally, the payload was stringifyed on line 44 and stored in the set as a json String. 
- In `expressServices.ts`, in the `redisPostmanRoomsRoute`, the arguments sent to `storeMessageInSet` were changed to match the updated function signature 
- In `socketServices.ts` a `parseMessages` helper function on lines 49-54 is called on line 62 to parse the array of json Strings returned from Redis into `'message'` strings so this works with the front end - **Note to avoid the app throwing an error with this new feature be sure that you clear your `localStorage` before connecting**