### PR TITLE
implemented long-term state recovery

### DIFF
--- a/ws_server/src/db/dynamoService.ts
+++ b/ws_server/src/db/dynamoService.ts
@@ -64,6 +64,7 @@ export const readPreviousMessagesByRoom = async (room_id: string, last_timestamp
     });
 
     const response = await client.send(command);
+
     const unmarshalledItems = (response.Items || []).map((item) =>
       unmarshall(item)
     );


### PR DESCRIPTION
In `messages.js` we removed all of the previous `socket.auth.offset` code both in the events as well as the socket creation code at the top (`socket.io(localhost...)`)

In `socketServices.js` we updated the following functions: 

- `emitLongTermReconnectionStateRecovery`, here we had to update the param type as well as the `for` loop iterating through the `rooms` argument since it was no longer an object, but an array.

- `resubscribe`,  here we made the same update as the function mentioned above.

Debugging the state recovery took up most of our time and led us to the fixes needed above.

TODOS:
We noticed an issue with state recovery, when a server goes down the `sessionTimestamp` doesn't update because the `disconnecting` event never occurs. This results in a user receiving every message for the rooms they're subscribed to because the last session time recorded was upon their initial connection or a previous disconnection time.