### PR TITLE
updated emit func to emit to the specified room and #publish as well

### DIFF
--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -50,7 +50,7 @@ export const publish = async (req: Request, res: Response) => {
 
   console.log("Data Payload Emitting", data.payload);
 
-  io.in(data.room_id).emit("message", data.payload);
+  io.to(data.room_id).emit("message", data.payload);
 
   res.status(201).send('ok');
 }

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -50,7 +50,7 @@ export const publish = async (req: Request, res: Response) => {
 
   console.log("Data Payload Emitting", data.payload);
 
-  io.to(data.room_id).emit("message", data.payload);
+  io.in(data.room_id).emit("message", data.payload);
 
   res.status(201).send('ok');
 }

--- a/ws_server/src/services/socketServices.ts
+++ b/ws_server/src/services/socketServices.ts
@@ -1,5 +1,4 @@
 import { v4 as uuid4 } from 'uuid';
-import { io } from '../index.js'; // will need for io.to().emit
 import { Socket } from "socket.io";
 import { setSessionTime, redisMissedMessages, addRoomToSession, checkSessionTimestamp, redisSubscribedRooms, processSubscribedRooms } from '../db/redisService.js';
 import { readPreviousMessagesByRoom } from '../db/dynamoService.js';
@@ -73,7 +72,7 @@ const emitLongTermReconnectionStateRecovery = async (socket: CustomSocket,
 const emitMessages = (room: string, socket: CustomSocket, messages: messageObject[]) => {
   messages.forEach(messages => {
     console.log('room message is emitting to', room)
-    io.in(room).emit("message", messages);
+    socket.emit("message", messages);
   });
 }
 


### PR DESCRIPTION
**Task:** Update general `#emit` function in `socketServices` to ensure messages are being sent to their respective `rooms`<br><br>

**I tried accomplishing the above task by updating the following functions in `socketServices`:**
- `emitShortTerm...` and `emitLongTerm...` were each updated to pass the current `room` in their iterations to `emitMessages()`
- `emitMessages` was updated to take 3 arguments, the only addt'l argument being `rooms: string`
  - the emit call was updated to `socket.to(room).emit('message', message)` as originally discussed but upon testing it didn't work as expected. 
  - `socket.to("room1").emit(/* ... */);` emitted missed messages to the user who remained connected, but not the user who reconnected and triggered the state recovery (i.e. the retrieval of those missed messages). This occurs upon both an intentional and unintentional disconnect.

**I ultimately decided to revert the functions `emitShortTerm...` and `emitLongTerm...` as well as the emit call (`socket.emit("message", messages)`) back to how they were originally.**


According to [Socket.io documentation](https://socket.io/docs/v3/emit-cheatsheet/),
  - `socket.to("room1").emit(/* ... */);` emits to all clients in room1 __except the sender__
    - I think this supports why it didn't work...perhaps since the reconnected socket is the sender in state recovery (`socket.emit`) that's why the reconnect socket/user doesn't receive it.

Since no code has changed, I will close this pull request and delete the branch `emitToSpecificRooms`