### PR TITLE
Removing stale sessionIds and messages from Redis

### DIFF
--- a/ws_server/src/db/redisCronJobs.ts
+++ b/ws_server/src/db/redisCronJobs.ts
@@ -1,7 +1,4 @@
 import { redis } from "../index.js"
-import { RedisKey } from "ioredis";
-
-const THREE_MINUTES_AGO = Date.now() - 180000;
 
 const getScoreOfItem = async (sortedSetKey: string, member: string) => {
   const score = await redis.zscore(sortedSetKey, member);
@@ -20,17 +17,21 @@ export const messageCronJob = () => {
   stream.on("data", (resultKeys) => {
     // allSortedSets is an array of all of the sorted sets in the Redis caches
     let allSortedSets = resultKeys;
+    console.log(allSortedSets); // ["BSet"]
 
     allSortedSets.forEach((set: string) => {
       // create a stream to iterate through the members of each sorted set
       const setStream = redis.zscanStream(set);
 
       setStream.on("data", (allMessages) => {
+        console.log(allMessages); // Should output all messages & output scores as well
 
         // iterate through all the messages in each sorted set
         allMessages.forEach(async (msg: string) => {
           let score = await getScoreOfItem(set, msg);
-          if (score && Number(score) < THREE_MINUTES_AGO) {
+          console.log("Msg with Score:", msg, score);
+
+          if (score && (Number(score) < (Date.now() - 180000))) {
             await removeItemFromSortedSet(set, msg);
           }
         })

--- a/ws_server/src/db/redisCronJobs.ts
+++ b/ws_server/src/db/redisCronJobs.ts
@@ -1,0 +1,42 @@
+import { redis } from "../index.js"
+import { RedisKey } from "ioredis";
+
+const THREE_MINUTES_AGO = Date.now() - 180000;
+
+const getScoreOfItem = async (sortedSetKey: string, member: string) => {
+  const score = await redis.zscore(sortedSetKey, member);
+  return score;
+}
+
+const removeItemFromSortedSet = async (sortedSetKey: string, member: string) => {
+  await redis.zrem(sortedSetKey, member)
+}
+
+export const messageCronJob = () => {
+
+  // creates a redis stream to retrieve all sorted sets
+  const stream = redis.scanStream({ type: "zset" });
+
+  stream.on("data", (resultKeys) => {
+    // allSortedSets is an array of all of the sorted sets in the Redis caches
+    let allSortedSets = resultKeys;
+
+    allSortedSets.forEach((set: string) => {
+      // create a stream to iterate through the members of each sorted set
+      const setStream = redis.zscanStream(set);
+
+      setStream.on("data", (allMessages) => {
+
+        // iterate through all the messages in each sorted set
+        allMessages.forEach(async (msg: string) => {
+          let score = await getScoreOfItem(set, msg);
+          if (score && Number(score) < THREE_MINUTES_AGO) {
+            await removeItemFromSortedSet(set, msg);
+          }
+        })
+
+      });
+    })
+  });
+};
+

--- a/ws_server/src/db/redisService.ts
+++ b/ws_server/src/db/redisService.ts
@@ -1,6 +1,7 @@
 import { currentTimeStamp } from "../utils/helpers.js";
 import { redis } from '../index.js';
 import "dotenv/config"
+import { messageCronJob } from "./redisCronJobs.js";
 
 const generateRandomStringPrefix = (payload: string) => {
   const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -57,10 +58,10 @@ export const redisMissedMessages = async (twineTS: number, subscribedRooms: Subs
     let joinTime = Number(subscribedRooms[room]);
     if (twineTS > joinTime) {
       console.log('twineTS is greater')
-      await processSubscribedRooms(twineTS+1, room, result);
+      await processSubscribedRooms(twineTS + 1, room, result);
     } else {
       console.log('joinTime is greater')
-      await processSubscribedRooms(joinTime+1, room, result);
+      await processSubscribedRooms(joinTime + 1, room, result);
     }
   }
 
@@ -95,3 +96,21 @@ export const addRoomToSession = async (sessionID: string, roomName: string) => {
 export const removeRoomFromSession = async (sessionID: string, roomName: string) => {
   await redis.hdel(`rooms:${sessionID}`, roomName);
 }
+
+// messageCronJob();
+
+/*
+Stale messages
+- set an expitry on messages stored in the room sorted sets to 3 minutes
+- Every 3 minutes,
+- retrive all the sorted sets in redis
+- if the score of the current item in the sorted set is > 3 minutes in the past then delete it from the sorted set
+    - 180,000 miliseconds in 3 minutes
+    - timestamp of 3 minute in past = (Date.now() - 180,000)
+    - if the timestamp - 3minutes in the past time stamp is < 0, its past expiration time and should be deleted
+
+Stale room sorted sets
+- create a cron job that deletes a sortedSet if it is empty at midnight every night
+
+await redis.set(sessionID, currentTime, "EX", SECONDS_IN_A_DAY);
+*/

--- a/ws_server/src/db/redisService.ts
+++ b/ws_server/src/db/redisService.ts
@@ -1,7 +1,6 @@
 import { currentTimeStamp } from "../utils/helpers.js";
 import { redis } from '../index.js';
 import "dotenv/config"
-import { messageCronJob } from "./redisCronJobs.js";
 
 const generateRandomStringPrefix = (payload: string) => {
   const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
@@ -96,21 +95,3 @@ export const addRoomToSession = async (sessionID: string, roomName: string) => {
 export const removeRoomFromSession = async (sessionID: string, roomName: string) => {
   await redis.hdel(`rooms:${sessionID}`, roomName);
 }
-
-// messageCronJob();
-
-/*
-Stale messages
-- set an expitry on messages stored in the room sorted sets to 3 minutes
-- Every 3 minutes,
-- retrive all the sorted sets in redis
-- if the score of the current item in the sorted set is > 3 minutes in the past then delete it from the sorted set
-    - 180,000 miliseconds in 3 minutes
-    - timestamp of 3 minute in past = (Date.now() - 180,000)
-    - if the timestamp - 3minutes in the past time stamp is < 0, its past expiration time and should be deleted
-
-Stale room sorted sets
-- create a cron job that deletes a sortedSet if it is empty at midnight every night
-
-await redis.set(sessionID, currentTime, "EX", SECONDS_IN_A_DAY);
-*/

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -4,8 +4,9 @@ import session from 'express-session';
 import express, { Request, Response, NextFunction } from 'express';
 import { handleConnection } from './services/socketServices.js';
 import { homeRoute, publish } from './services/expressServices.js';
-import { currentTimeStamp, hourExpiration, newUUID } from './utils/helpers.js';
+import { currentTimeStamp, dayExpiraton, newUUID } from './utils/helpers.js';
 import { Redis } from "ioredis"
+import { messageCronJob } from "./db/redisCronJobs.js";
 import connectRedis from 'connect-redis';
 import 'dotenv/config'
 
@@ -74,7 +75,7 @@ const sessionMiddleware = session({
   saveUninitialized: false,
   cookie: {
     httpOnly: true,
-    expires: hourExpiration(),
+    expires: dayExpiraton(),
   },
 });
 
@@ -87,7 +88,7 @@ declare module 'express-session' {
 }
 
 const cookieMiddleware = (req: Request, res: Response, next: NextFunction) => {
-  if (!req.session.twineID) { 
+  if (!req.session.twineID) {
     req.session.twineID = newUUID();
     // defualt twineTS must trigger difference of <2m or <24hr
     req.session.twineTS = currentTimeStamp();
@@ -155,6 +156,9 @@ io.on("connection", handleConnection);
 // Backend API
 app.get('/', homeRoute);
 app.post('/api/twine', publish);
+
+// cron job redis
+// messageCronJob();
 
 // listening on port 3001
 httpServer.listen(PORT, () => {

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -158,6 +158,10 @@ app.get('/', homeRoute);
 app.post('/api/twine', publish);
 
 // cron job redis
+setInterval(() => {
+  console.log("Interval Executing");
+  messageCronJob();
+}, 60000);
 // messageCronJob();
 
 // listening on port 3001

--- a/ws_server/src/utils/helpers.ts
+++ b/ws_server/src/utils/helpers.ts
@@ -9,8 +9,8 @@ export const newUUID = () => {
   return uuid4();
 }
 
-export const hourExpiration = () => {
+export const dayExpiraton = () => {
   const hourFromNow = new Date();
-  hourFromNow.setHours(hourFromNow.getHours() + 1);
+  hourFromNow.setHours(hourFromNow.getHours() + 24);
   return hourFromNow;
 }


### PR DESCRIPTION
- SessionIds will now be automatically removed from Redis if the user's last received message is greater than or equal to 24 hours 
  - This was implemented by adding a `expires` attribute on the cookie sent to the client on line 76 in `index.ts`, this expires attribute also automatically removes the associated sessionId in Redis when the expires time is up. 
  - The expires attribute is updated upon each message recieved on line 152 in `socketServices.ts`

- Messages sent greater than 3 minutes in the past will now be automatically removed from the associated room sorted set in Redis. If a sorted set doesn't contain any messages it will also automatically be deleted. 
  - Logic for this was implemented in `redisCronJobs.ts` in the `db` folder
  - For now, the `messageCronJob` function is executed on an interval every minute on lines 161-164 in `index.ts` this will be transferred to a Cron Job script for deployment