### PR TITLE
scheduled redis cleanup into a cron job, added hard limit to Redis messages

### DIFF
--- a/ws_server/package.json
+++ b/ws_server/package.json
@@ -34,6 +34,7 @@
     "ioredis": "^5.3.2",
     "mongodb": "^6.1.0",
     "mongoose": "^5.13.20",
+    "node-cron": "^3.0.2",
     "socket.io": "^4.7.2",
     "uuid": "^9.0.1"
   },
@@ -42,6 +43,7 @@
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.20",
     "@types/express-session": "^1.17.9",
+    "@types/node-cron": "^3.0.10",
     "@types/uuid": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^6.2.0",
     "@typescript-eslint/parser": "^6.2.0",

--- a/ws_server/src/db/redisCronJobs.ts
+++ b/ws_server/src/db/redisCronJobs.ts
@@ -1,4 +1,4 @@
-import { redis } from "../index.js"
+import { redis } from "../index.js";
 
 const getScoreOfItem = async (sortedSetKey: string, member: string) => {
   const score = await redis.zscore(sortedSetKey, member);
@@ -10,6 +10,7 @@ const removeItemFromSortedSet = async (sortedSetKey: string, member: string) => 
 }
 
 export const messageCronJob = () => {
+  console.log("Cron Job executed")
 
   // creates a redis stream to retrieve all sorted sets
   const stream = redis.scanStream({ type: "zset" });
@@ -36,4 +37,3 @@ export const messageCronJob = () => {
     })
   });
 };
-

--- a/ws_server/src/db/redisService.ts
+++ b/ws_server/src/db/redisService.ts
@@ -19,9 +19,16 @@ const removeRandomStringPrefixs = (arrayOfMessages: string[]) => {
 }
 
 export const storeMessageInSet = async (room: string, payload: string, timestamp: number) => {
+  let lengthOfSet = await redis.zcard(`${room}Set`);
   let randomizedPayload = generateRandomStringPrefix(payload);
-  await redis.zadd(`${room}Set`, timestamp, randomizedPayload);
-  console.log('Message stored in cache: ' + randomizedPayload);
+
+  if (lengthOfSet >= 100) {
+    console.log("Set exceeds 100 messages, please try again later");
+    return;
+  } else {
+    await redis.zadd(`${room}Set`, timestamp, randomizedPayload);
+    console.log('Message stored in cache: ' + randomizedPayload);
+  }
 }
 
 interface SubscribedRoomMessages {

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -9,6 +9,7 @@ import { Redis } from "ioredis"
 import { messageCronJob } from "./db/redisCronJobs.js";
 import connectRedis from 'connect-redis';
 import 'dotenv/config'
+import cron from 'node-cron';
 
 const redisURL = process.env.CACHE_ENDPOINT || 'redis://localhost:6379';
 export const redis: Redis = new Redis(redisURL);
@@ -158,10 +159,9 @@ app.get('/', homeRoute);
 app.post('/api/twine', publish);
 
 // cron job redis
-setInterval(() => {
-  messageCronJob();
-}, 60000);
-// messageCronJob();
+const cronSchedule = "*/3 * * * *"; // runs every 3 minutes
+cron.schedule(cronSchedule, messageCronJob);
+
 
 // listening on port 3001
 httpServer.listen(PORT, () => {


### PR DESCRIPTION
- Scheduled cleaning up stale messages in redis into a cron job 
  - installed `node-cron` 
  - In `index.ts` imported `cron` from `node-cron` , scheduled cronJob on line 162 and 163 to run every 3 minutes

- Added hard limit (100 messages) to the amount of messages able to be stored in Redis for a particular room 
  - Added logic to `storeMessageInSet` in `redisService.ts` , `redis.zcard` returns the length of a room's sorted set, if that length is equal to or exceeds 100 then the incoming message is not stored in the set 