### PR TITLE
emit room_id client-side and removed a #validate condition

### DIFF
--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -9,6 +9,7 @@ const socket = io('http://localhost:3001', {
 // Handle successful connection
 socket.on("message", (data) => {
   console.log('data from client: ', data);
+  console.log('room id from client: ', data.room);
   socket.emit("updateSessionTS", (data.timestamp));
   const messages = document.getElementById('messages');
   const item = document.createElement('li');

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -25,12 +25,10 @@ const httpServer = createServer(app);
 
 class CustomStore extends session.Store {
   redis: session.Store;
-  // dynamo: session.Store;
 
   constructor(redis: session.Store) {
     super();
     this.redis = redis;
-    // this.dynamo = dynamo;
   }
 
   get(sid: string, callback: (err: any, session?: session.SessionData | null) => void): void {
@@ -41,28 +39,18 @@ class CustomStore extends session.Store {
         callback(null, session ?? null);
       }
     });
-    // this.dynamo.get(sid, (err, session) => {
-    //   if (err) {
-    //     callback(err);
-    //   } else {
-    //     callback(null, session ?? null);
-    //   }
-    // });
   }
 
   set(sid: string, session: session.SessionData, callback?: (err?: any) => void): void {
     this.redis.set(sid, session, callback);
-    // this.dynamo.set(sid, session, callback);
   }
 
   destroy(sid: string, callback?: (err?: any) => void): void {
     this.redis.destroy(sid, callback);
-    // this.dynamo.destroy(sid, callback);
   }
 }
 
-const redisStore: session.Store = redisSessionStore; // redis store instance
-// const dynamoStore: session.Store = dynamoSessionStore // dynamo store instance
+const redisStore: session.Store = redisSessionStore;
 const customStore = new CustomStore(redisStore);
 
 // Express Middleware

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -4,12 +4,12 @@ import { createMessage } from "../db/dynamoService.js";
 import { storeMessageInSet } from '../db/redisService.js';
 import { currentTimeStamp } from '../utils/helpers.js';
 
-type DynamoCreateResponse = {
-  status_code: number | undefined,
-  room_id: string,
-  time_created: number,
-  payload: object
-}
+// type DynamoCreateResponse = {
+//   status_code: number | undefined,
+//   room_id: string,
+//   time_created: number,
+//   payload: object
+// }
 
 interface messageObject {
   message: string;

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -58,9 +58,7 @@ const validate = (data: jsonData) => {
   } else if (!room_id || !payload) {
     throw Error('Malformed Request: One or more required parameters is missing')
 
-  } else if(room_id 
-    && (typeof payload !== 'object' 
-    || !Object.keys(payload).includes('message'))) {
+  } else if(room_id && (typeof payload !== 'object')) {
 
     throw Error('Malformed Request: One or more parameter values is of an incorrect data type.')
   }

--- a/ws_server/src/services/socketServices.ts
+++ b/ws_server/src/services/socketServices.ts
@@ -20,6 +20,7 @@ interface DynamoMessage {
 interface messageObject {
   message: string;
   timestamp: number;
+  room: string;
 }
 
 const SHORT_TERM_RECOVERY_TIME_MAX = 120000;
@@ -57,7 +58,7 @@ const emitShortTermReconnectionStateRecovery = async (socket: CustomSocket, time
   for (let room in messagesObj) {
     let messages = parseRedisMessages(messagesObj[room]);
     console.log("Messages for each room returned from redis", messages)
-    emitMessages(socket, messages);
+    emitMessages(socket, messages, room);
   }
 }
 
@@ -74,14 +75,15 @@ const parseDynamoMessages = (dynamomessages: DynamoMessage[]) => {
 //   for (let room of rooms) {
 //     let messages = await readPreviousMessagesByRoom(room, lastDisconnect) as DynamoMessage[];
 //     let parsedMessages = parseDynamoMessages(messages);
-//     emitMessages(socket, parsedMessages);
+//     emitMessages(socket, parsedMessages, room);
 //   }
 // }
 
-const emitMessages = (socket: CustomSocket, messages: messageObject[]) => {
+const emitMessages = (socket: CustomSocket, messages: messageObject[], room_id: string) => {
   const time = currentTimeStamp();
   messages.forEach(message => {
     message["timestamp"] = time;
+    message["room"] = room_id;
     socket.emit("message", message);
   });
 }


### PR DESCRIPTION
**Task:** Remove last condition of last `else/if` branch (`!Object.keys(payload).includes('message')`)

Updated `#validate` function in `expressServices` to remove the condition specified above because the developer may want to name the property `messages` a different name, therefore this condition shouldn't be hardcoded.<br><br>

**Task:** Emit `room_id` client-side along with message data

In `socketServices`, I updated the following items:
- `messageObject`: A `room` property typed `string` was added
- `#emitMessages`: An add'tl argument `room_id: string` was added to the function expression, the value for which was also added to `messages` as a property, `room`, that can be accessed client-side
- `emitShortTerm...Recovery` and `emitLongTerm...Recovery`: Each was updated to pass the current room in their respective iterations to `emitMessages()`

In `expressServices`, I did not update the `messageObject` nor did I add a `room` property to the `data.payload` being emitted client-side. This is because the `#emit` function is chained to `io.to(data.room_id)`, which will allow the developer access to the room id.

**Additional changes:** Since we're no longer using DynamoDB as a session store, I removed all code of it from `index.ts`