### PR TITLE
Cover long term edge case and add hard limit

### DIFF
--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -9,6 +9,7 @@ const socket = io('http://localhost:3001', {
 // Handle successful connection
 socket.on("message", (data) => {
   console.log('data from client: ', data);
+  console.log('room id from client: ', data.room);
   socket.emit("updateSessionTS", (data.timestamp));
   const messages = document.getElementById('messages');
   const item = document.createElement('li');

--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -9,7 +9,6 @@ const socket = io('http://localhost:3001', {
 // Handle successful connection
 socket.on("message", (data) => {
   console.log('data from client: ', data);
-  console.log('room id from client: ', data.room);
   socket.emit("updateSessionTS", (data.timestamp));
   const messages = document.getElementById('messages');
   const item = document.createElement('li');

--- a/ws_server/src/db/dynamoService.ts
+++ b/ws_server/src/db/dynamoService.ts
@@ -1,7 +1,6 @@
 import {
   DynamoDBClient,
   DynamoDBClientConfig,
-  ScanCommand,
   QueryCommand
 } from "@aws-sdk/client-dynamodb";
 import {
@@ -53,7 +52,6 @@ export const createMessage = async (room_id: string, message: string) => {
     return error // passing error to #publishToDynamo
   }
 };
-
 
 
 export const readPreviousMessagesByRoom = async (room_id: string, last_timestamp: number) => {

--- a/ws_server/src/services/socketServices.ts
+++ b/ws_server/src/services/socketServices.ts
@@ -75,6 +75,7 @@ const emitLongTermReconnectionStateRecovery = async (socket: CustomSocket, times
 
   for (let room in rooms) {
     let joinTime = Number(rooms[room]);
+    console.log('room', room)
     if (timestamp > joinTime) { 
       console.log('twineTS is greater')
       messages = await readPreviousMessagesByRoom(room, timestamp + 1) as DynamoMessage[];
@@ -82,7 +83,7 @@ const emitLongTermReconnectionStateRecovery = async (socket: CustomSocket, times
       console.log('joinTime is greater')
       messages = await readPreviousMessagesByRoom(room, joinTime + 1) as DynamoMessage[];
     }
-
+    console.log('retrieved long-term messages', messages)
     let parsedMessages = parseDynamoMessages(messages);
     emitMessages(socket, parsedMessages, room);
   }
@@ -120,14 +121,12 @@ export const handleConnection = async (socket: CustomSocket) => {
     console.log("timeSinceLastDisconnect: ", timeSinceLastTimestamp);
 
     if (timeSinceLastTimestamp <= SHORT_TERM_RECOVERY_TIME_MAX) { // less than 2 mins (milliseconds)
-    // if (false) { // less than 2 mins (milliseconds)
       console.log('short term state recovery branch executed')
       // add conditional that checks if there is a missed message? within `emitShort` before emitting?
       emitShortTermReconnectionStateRecovery(socket, socket.twineTS, subscribedRooms);
     } else if (timeSinceLastTimestamp <= LONG_TERM_RECOVERY_TIME_MAX) { // less than 24 hrs (milliseconds)
       console.log('long term state recovery branch executed')
       // add conditional that checks if there is a missed message?  within `emitLong` before emitting?
-      // commented out because need to implement twineTS vs. joinTime logic in Dynamo
       emitLongTermReconnectionStateRecovery(socket, socket.twineTS, subscribedRooms);
     }
   }


### PR DESCRIPTION
**Task:** Update `#emitLongTerm...Recovery` to handle new `SubscribedRooms` format and cover `joinRoom` vs `twineTS` edge case.

Iteration in `#emitLongTerm...Recovery` has been changed from a `for/of` to a `for/in` loop to adjust to `SubscribedRooms` format, `{ roomA: joinTime, roomB: joinTime, etc }`.

Logic to handle `joinRoom` vs `twineTS` edge case was copied over from `rediseServices`. We're only providing _state recovery_ in the case of a user unintentionally disconnecting, therefore if a user joins a previously active room they will not see old messages because our concern is transmitted _missed_ messages (i.e. messages the user would have received had their connection not been disrupted). Without this logic...

<br>**Task:** Add hard limits to no. of messages that are returned by Dynamo
Updated `#readPreviousMessagesByRoom` function in `dynamoServices` by converting the `ScanCommand` to a `QueryCommand` and implementing a `while` loop that continuously queries the DB for missed messages until we've either retrieved all of the missed messages there are or hit our limit of 1000.

The switch from `Scan` to `Query` was made because a scan looks at _all_ table items, then removes items that don't match our `KeyConditionExpression`, which will ultimately become a slower operation as the table grows.
