### PR TITLE
adding socket io adapter

### DIFF
--- a/ws_server/package.json
+++ b/ws_server/package.json
@@ -25,6 +25,8 @@
     "@aws-sdk/credential-providers": "^3.430.0",
     "@aws-sdk/lib-dynamodb": "^3.430.0",
     "@aws-sdk/util-dynamodb": "^3.433.0",
+    "@socket.io/redis-adapter": "^8.2.1",
+    "@types/redis": "^4.0.11",
     "connect-redis": "^7.1.0",
     "cookie": "^0.5.0",
     "cookie-session": "^2.0.0",
@@ -36,6 +38,7 @@
     "mongodb": "^6.1.0",
     "mongoose": "^5.13.20",
     "node-cron": "^3.0.2",
+    "redis": "^4.6.10",
     "socket.io": "^4.7.2",
     "uuid": "^9.0.1"
   },

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -7,6 +7,7 @@ import { handleConnection } from './services/socketServices.js';
 import { homeRoute, publish } from './services/expressServices.js';
 import { currentTimeStamp, dayExpiraton, newUUID } from './utils/helpers.js';
 import { Cluster } from "ioredis"
+import { createAdapter } from "@socket.io/redis-adapter"
 // import { Redis } from "ioredis"
 import { messageCronJob } from "./db/redisCronJobs.js";
 // import connectRedis from 'connect-redis';
@@ -169,6 +170,9 @@ export const io = new Server<
 //  headers["set-cookie"] = serialize("twine", newUUID(), { sameSite: "none", secure: true, httpOnly: true, maxAge: 24 * 60 * 60 * 1000 });
 //});
 
+// Adapter logic
+const subClient = redis.duplicate();
+io.adapter(createAdapter(redis, subClient));
 
 // WS Server Logic
 io.on("connection", handleConnection);


### PR DESCRIPTION
- Added redis-socket.io adapter functionality to allow for synchronization of publish/subscribe and connection state recovery functionality amongst multiple EC2 instances
  - Installed `socket.io/redis-adapter`
  - Added adapter logic in `index.ts` on lines 174 and 175